### PR TITLE
Optimize task seeding with PostgreSQL binary import

### DIFF
--- a/src/Infrastructure/Data/Configurations/TaskConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/TaskConfiguration.cs
@@ -26,6 +26,7 @@ public class TaskConfiguration : IEntityTypeConfiguration<Task>
         
         builder.HasIndex(t => t.AssigneeId);
         builder.HasIndex(t => t.CreatorId);
+        builder.HasIndex(t => t.CreatedAt);
         builder.HasIndex(t => new { t.Status, t.Priority });
     }
 }


### PR DESCRIPTION
- Introduced an index on the `CreatedAt` column in `TaskConfiguration` to enhance query performance.
- Replaced Entity Framework Core task seeding functionality with PostgreSQL binary import, significantly improving efficiency and scalability for database operations.