### PR TITLE
Add health checks for RabbitMQ, PostgreSQL, and Redis

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageVersion Include="CloudinaryDotNet" Version="1.27.9" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.Common.Interfaces;
 using Application.Common.Options;
+using Ardalis.GuardClauses;
 using CloudinaryDotNet;
 using Domain.Constants;
 using Infrastructure.BackgroundWorker;
@@ -33,7 +34,7 @@ public static class DependencyInjection
     public static void AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
     {
         var connectionString = configuration.GetConnectionString("DefaultConnection")
-                               ?? throw new InvalidOperationException("Connection string 'TodoDb' not found.");
+                               ?? throw new InvalidOperationException("Connection string not found.");
         
         QuestPDF.Settings.License = LicenseType.Community;
         services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor>();
@@ -139,7 +140,10 @@ public static class DependencyInjection
         services.AddSingleton<IConnectionMultiplexer>(sp =>
         {
             var config = sp.GetRequiredService<IConfiguration>();
-            var redisConnectionString = config["Caching:Redis:ConnectionString"] ?? "localhost:6379"; 
+            var redisConnectionString = Guard.Against.NullOrWhiteSpace(
+                config["Caching:Redis:ConnectionString"],
+                "Redis connection string is not configured.");
+
             return ConnectionMultiplexer.Connect(redisConnectionString);
         });
         services.AddScoped<IRedisCacheService, RedisCacheService>();

--- a/src/Web/DependencyInjection.cs
+++ b/src/Web/DependencyInjection.cs
@@ -11,6 +11,13 @@ public static class DependencyInjection
 {
     public static void AddWebServices(this IServiceCollection services, IConfiguration configuration)
     {
+        var connectionString = Guard.Against.NullOrWhiteSpace(
+            configuration.GetConnectionString("DefaultConnection"),
+            message: "Connection string 'DefaultConnection' is not configured.");
+        var redisConnectionString = Guard.Against.NullOrWhiteSpace(
+            configuration["Caching:Redis:ConnectionString"],
+            message: "Redis connection string is not configured.");
+
         var allowedOrigins = configuration["Cors:AllowedOrigins"]
             ?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
         services.AddOpenApi();
@@ -47,5 +54,6 @@ public static class DependencyInjection
             });
             
         });
+        services.AddHealthChecks().AddNpgSql(connectionString).AddRedis(redisConnectionString);
     }
 }

--- a/src/Web/DependencyInjection.cs
+++ b/src/Web/DependencyInjection.cs
@@ -1,8 +1,10 @@
 using System.Text.Json.Serialization;
- using Application.Common.Options;
+using Application.Common.Options;
 using Ardalis.GuardClauses;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using NSwag;
+using Task_Management_BE.HealthChecks;
 using Web.Infrastructure;
 
 namespace Task_Management_BE;
@@ -54,6 +56,10 @@ public static class DependencyInjection
             });
             
         });
-        services.AddHealthChecks().AddNpgSql(connectionString).AddRedis(redisConnectionString);
+        services.AddHealthChecks()
+            .AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live", "ready"])
+            .AddNpgSql(connectionString, name: "postgresql", tags: ["ready"])
+            .AddRedis(redisConnectionString, name: "redis", tags: ["ready"])
+            .AddCheck<RabbitMqHealthCheck>("rabbitmq", tags: ["ready"]);
     }
 }

--- a/src/Web/Endpoints/Health.cs
+++ b/src/Web/Endpoints/Health.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Task_Management_BE.Infrastructure;
+
+namespace Task_Management_BE.Endpoints;
+
+public class Health : EndpointGroupBase
+{
+    public override void Map(WebApplication app)
+    {
+        app.MapGroup(this)
+            .MapHealthChecks("", new HealthCheckOptions
+            {
+                ResponseWriter = async (context, report) =>
+                {
+                    context.Response.ContentType = "application/json";
+
+                    var response = new
+                    {
+                        status = report.Status.ToString(),
+                        totalDuration = report.TotalDuration,
+                        checks = report.Entries.ToDictionary(
+                            entry => entry.Key,
+                            entry => new
+                            {
+                                status = entry.Value.Status.ToString(),
+                                description = entry.Value.Description,
+                                duration = entry.Value.Duration,
+                                error = entry.Value.Exception?.Message
+                            })
+                    };
+
+                    await JsonSerializer.SerializeAsync(context.Response.Body, response, cancellationToken: context.RequestAborted);
+                }
+            });
+    }
+}

--- a/src/Web/Endpoints/Health.cs
+++ b/src/Web/Endpoints/Health.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Task_Management_BE.Infrastructure;
 
 namespace Task_Management_BE.Endpoints;
@@ -8,30 +9,40 @@ public class Health : EndpointGroupBase
 {
     public override void Map(WebApplication app)
     {
-        app.MapGroup(this)
-            .MapHealthChecks("", new HealthCheckOptions
-            {
-                ResponseWriter = async (context, report) =>
+        var group = app.MapGroup(this);
+
+        group.MapHealthChecks("", CreateHealthCheckOptions("ready"));
+        group.MapHealthChecks("/live", CreateHealthCheckOptions("live"));
+    }
+
+    private static HealthCheckOptions CreateHealthCheckOptions(string tag)
+    {
+        return new HealthCheckOptions
+        {
+            Predicate = check => check.Tags.Contains(tag),
+            ResponseWriter = WriteResponseAsync
+        };
+    }
+
+    private static Task WriteResponseAsync(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var response = new
+        {
+            status = report.Status.ToString(),
+            totalDuration = report.TotalDuration,
+            checks = report.Entries.ToDictionary(
+                entry => entry.Key,
+                entry => new
                 {
-                    context.Response.ContentType = "application/json";
+                    status = entry.Value.Status.ToString(),
+                    description = entry.Value.Description,
+                    duration = entry.Value.Duration,
+                    error = entry.Value.Exception?.Message
+                })
+        };
 
-                    var response = new
-                    {
-                        status = report.Status.ToString(),
-                        totalDuration = report.TotalDuration,
-                        checks = report.Entries.ToDictionary(
-                            entry => entry.Key,
-                            entry => new
-                            {
-                                status = entry.Value.Status.ToString(),
-                                description = entry.Value.Description,
-                                duration = entry.Value.Duration,
-                                error = entry.Value.Exception?.Message
-                            })
-                    };
-
-                    await JsonSerializer.SerializeAsync(context.Response.Body, response, cancellationToken: context.RequestAborted);
-                }
-            });
+        return JsonSerializer.SerializeAsync(context.Response.Body, response, cancellationToken: context.RequestAborted);
     }
 }

--- a/src/Web/HealthChecks/RabbitMqHealthCheck.cs
+++ b/src/Web/HealthChecks/RabbitMqHealthCheck.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using RabbitMQ.Client;
+
+namespace Task_Management_BE.HealthChecks;
+
+public sealed class RabbitMqHealthCheck(IConfiguration configuration) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var factory = new ConnectionFactory
+            {
+                HostName = configuration["RabbitMq:HostName"] ?? "localhost",
+                UserName = configuration["RabbitMq:UserName"] ?? "admin",
+                Password = configuration["RabbitMq:Password"] ?? "admin",
+                VirtualHost = configuration["RabbitMq:VirtualHost"] ?? "/",
+                Port = configuration.GetValue<int?>("RabbitMq:Port") ?? 5672
+            };
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var connection = await factory.CreateConnectionAsync();
+
+            return connection.IsOpen
+                ? HealthCheckResult.Healthy("RabbitMQ is reachable.")
+                : HealthCheckResult.Unhealthy("RabbitMQ connection is closed.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("RabbitMQ is unreachable.", exception);
+        }
+    }
+}

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+        <PackageReference Include="AspNetCore.HealthChecks.Redis" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
```
### Summary

This pull request introduces health checks for key system dependencies, ensuring better monitoring and fault detection.

### Changes

- Added `RabbitMqHealthCheck` to validate RabbitMQ connectivity.
- Integrated PostgreSQL and Redis health checks using appropriate packages.
- Enhanced the `Health` endpoint to provide categorized readiness and liveness probes.
- Updated dependency injection to properly register health checks with readiness tagging.

### Testing

- Verified the `Health` endpoint responds correctly with categorized system health.
- Simulated connectivity issues to confirm accurate health statuses are reflected.
```