### PR TITLE
Refactor notification dispatch modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@
   ```
 
 ## Notification Worker (SignalR publishing via web API)
-- The worker publishes notifications by calling the web API endpoint `POST /api/NotificationsInternal/internal/notifications`.
+- Notification dispatch is controlled by `Notifications:DispatchMode`.
+- Supported values:
+  - `InProcess`: the API stores notifications and pushes SignalR updates directly.
+  - `RabbitMq`: the API publishes notification events to RabbitMQ, and the worker consumes them.
+- Default behavior:
+  - `Development` defaults to `RabbitMq`.
+  - Non-development environments default to `InProcess`.
+- The worker is only required when `Notifications:DispatchMode=RabbitMq`.
+- When RabbitMQ mode is enabled, the worker publishes notifications by calling the web API endpoint `POST /api/NotificationsInternal/internal/notifications`.
 - Configure these settings for both the web app and the worker:
   - `WorkerApiKey`: shared secret sent in the `X-Worker-Key` header.
   - `WebBaseUrl`: base URL for the web app (worker only), e.g. `http://localhost:5000/`.
@@ -72,6 +80,8 @@
   # edit .env and set POSTGRES_PASSWORD and API_CONNECTION_STRING as needed
   ```
 - Set `ALLOWED_ORIGINS` in `.env` using a semicolon-separated list (e.g. `http://localhost:3000;https://app.example.com`). The API reads `Cors:AllowedOrigins` from that environment variable when running in Docker.
+- Development compose explicitly sets `Notifications__DispatchMode=RabbitMq` to keep the RabbitMQ + worker flow available locally.
+- Production compose explicitly sets `Notifications__DispatchMode=InProcess` so notification creation runs inside the API process.
 - To enable distributed caching with Redis, set the connection string (example uses local Redis):
   - `Caching__Redis__ConnectionString=localhost:6379,abortConnect=false`
 - Build and run the stack (API + Postgres):
@@ -100,10 +110,26 @@
 
 ## Heroku Container Deployment
 
-This application is deployed to Heroku as two Docker process types:
+This application can be deployed to Heroku as one or two Docker process types:
 
 - `web`: ASP.NET Core API and SignalR hub.
-- `worker`: notification worker that consumes RabbitMQ messages and calls the internal notification API.
+- `worker`: optional notification worker that consumes RabbitMQ messages and calls the internal notification API.
+
+For the cheaper production path, use:
+
+```text
+Notifications__DispatchMode=InProcess
+```
+
+With this mode, the `worker` dyno and RabbitMQ are not required for task notifications.
+
+For development or event-driven testing, use:
+
+```text
+Notifications__DispatchMode=RabbitMq
+```
+
+With this mode, release and scale the `worker` process too.
 
 ### 1. Create and Prepare the Heroku App
 
@@ -159,6 +185,7 @@ heroku config:set \
   RabbitMq__VirtualHost="<rabbitmq-virtual-host>" \
   RabbitMq__Port=5671 \
   RabbitMq__UseSsl=true \
+  Notifications__DispatchMode=InProcess \
   WebBaseUrl="https://<app-name>.herokuapp.com/" \
   WorkerApiKey="<shared-worker-key>" \
   Cors__AllowedOrigins="http://localhost:3000;https://your-frontend.example.com" \
@@ -170,6 +197,8 @@ If structured database, Redis, or RabbitMQ settings are absent, the app falls ba
 - `DATABASE_URL` -> `ConnectionStrings:DefaultConnection`
 - `REDIS_URL` -> `Caching:Redis:ConnectionString`
 - `CLOUDAMQP_URL` -> `RabbitMq:*`
+
+RabbitMQ settings are only required by the web app when `Notifications__DispatchMode=RabbitMq`. They are still required by the worker if the worker process is deployed.
 
 ### 4. Build and Push Images
 
@@ -205,19 +234,31 @@ docker push registry.heroku.com/<app-name>/worker
 
 ### 5. Release and Scale Processes
 
-Release both process types:
+Release the web process:
+
+```bash
+heroku container:release web -a <app-name>
+```
+
+For RabbitMQ mode, release both process types:
 
 ```bash
 heroku container:release web worker -a <app-name>
 ```
 
-Scale both dynos:
+Scale the production in-process path:
+
+```bash
+heroku ps:scale web=1 worker=0 -a <app-name>
+```
+
+Scale the RabbitMQ worker path:
 
 ```bash
 heroku ps:scale web=1 worker=1 -a <app-name>
 ```
 
-The worker is required for RabbitMQ-backed notifications. If only `web` is running, notifications may be stored by API workflows, but queued task notification events will not be consumed.
+The worker is required only for RabbitMQ-backed notifications. If `Notifications__DispatchMode=RabbitMq` and only `web` is running, queued task notification events will not be consumed.
 
 ### 6. Verify Deployment
 
@@ -227,7 +268,13 @@ Check dynos:
 heroku ps -a <app-name>
 ```
 
-Expected process types:
+Expected process types for in-process mode:
+
+```text
+web.1: up
+```
+
+Expected process types for RabbitMQ mode:
 
 ```text
 web.1: up
@@ -241,7 +288,7 @@ curl https://<app-name>.herokuapp.com/api/health/live
 curl https://<app-name>.herokuapp.com/api/health
 ```
 
-The ready health endpoint should report healthy PostgreSQL, Redis, and RabbitMQ checks.
+The ready health endpoint should report healthy PostgreSQL and Redis checks. RabbitMQ is included in health checks only when `Notifications__DispatchMode=RabbitMq`.
 
 Check logs:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
       Cloudinary__CloudName: ${DEV_CLOUDINARY_CLOUD_NAME}
       Cloudinary__ApiKey: ${DEV_CLOUDINARY_API_KEY}
       Cloudinary__ApiSecret: ${DEV_CLOUDINARY_API_SECRET}
+      Notifications__DispatchMode: RabbitMq
       WorkerApiKey: ${DEV_WORKER_API_KEY}
       RabbitMq__HostName: rabbitmq
       RabbitMq__UserName: ${DEV_RABBITMQ_DEFAULT_USER}
@@ -33,6 +34,7 @@ services:
       target: worker
     environment:
       ASPNETCORE_ENVIRONMENT: Development
+      Notifications__DispatchMode: RabbitMq
       WebBaseUrl: http://api:8080/
       WorkerApiKey: ${DEV_WORKER_API_KEY}
       RabbitMq__HostName: rabbitmq

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
       Cloudinary__CloudName: ${CLOUDINARY_CLOUD_NAME}
       Cloudinary__ApiKey: ${CLOUDINARY_API_KEY}
       Cloudinary__ApiSecret: ${CLOUDINARY_API_SECRET}
+      Notifications__DispatchMode: InProcess
     ports:
       - "8080:8080"
   postgres:

--- a/src/Application/Common/Interfaces/INotificationDispatcher.cs
+++ b/src/Application/Common/Interfaces/INotificationDispatcher.cs
@@ -1,0 +1,11 @@
+using Application.Common.Models;
+
+namespace Application.Common.Interfaces;
+
+public interface INotificationDispatcher
+{
+    Task DispatchAsync(
+        NotificationIntegrationEvent notification,
+        string routingKey,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Application/Common/Models/NotificationIntegrationEvent.cs
+++ b/src/Application/Common/Models/NotificationIntegrationEvent.cs
@@ -7,5 +7,7 @@ public sealed record NotificationIntegrationEvent
     public NotificationType Type { get; init; }
     public string Message { get; init; } = default!;
     public string UserId { get; init; } = default!;
+    public string? ActionUrl { get; init; }
+    public string? ActionLabel { get; init; }
     public DateTimeOffset OccuredAt { get; init; } = DateTimeOffset.UtcNow;
 }

--- a/src/Application/Common/Options/NotificationDispatchOptions.cs
+++ b/src/Application/Common/Options/NotificationDispatchOptions.cs
@@ -1,0 +1,14 @@
+namespace Application.Common.Options;
+
+public sealed class NotificationDispatchOptions
+{
+    public const string SectionName = "Notifications";
+
+    public string DispatchMode { get; init; } = NotificationDispatchModes.InProcess;
+}
+
+public static class NotificationDispatchModes
+{
+    public const string InProcess = "InProcess";
+    public const string RabbitMq = "RabbitMq";
+}

--- a/src/Application/Features/Tasks/EventHandlers/TaskAssignedEventHandler.cs
+++ b/src/Application/Features/Tasks/EventHandlers/TaskAssignedEventHandler.cs
@@ -7,7 +7,7 @@ using MediatR;
 namespace Application.Features.Tasks.EventHandlers;
 
 public class TaskAssignedEventHandler(
-    IMessageBus messageBus
+    INotificationDispatcher notificationDispatcher
     ) : INotificationHandler<TaskAssignedEvent>
 {
     public async Task Handle(TaskAssignedEvent notification, CancellationToken cancellationToken)
@@ -18,6 +18,6 @@ public class TaskAssignedEventHandler(
             Message = $"You have been assigned to task '{notification.Title}'.",
             UserId = notification.AssigneeId
         };
-        await messageBus.PublishAsync(integrationEvent, exchange: "task.events", routingKey: "task.assigned", cancellationToken);
+        await notificationDispatcher.DispatchAsync(integrationEvent, routingKey: "task.assigned", cancellationToken);
     }
 }

--- a/src/Application/Features/Tasks/EventHandlers/TaskCreatedEventHandler.cs
+++ b/src/Application/Features/Tasks/EventHandlers/TaskCreatedEventHandler.cs
@@ -7,7 +7,7 @@ using MediatR;
 namespace Application.Features.Tasks.EventHandlers;
 
 public class TaskCreatedEventHandler(
-    IMessageBus messageBus
+    INotificationDispatcher notificationDispatcher
     ) : INotificationHandler<TaskCreatedEvent>
 {
     public async Task Handle(TaskCreatedEvent notification, CancellationToken cancellationToken)
@@ -19,6 +19,6 @@ public class TaskCreatedEventHandler(
             Message = $"Task '{task.Title}' has been created.",
             UserId = task.CreatorId!,
         };
-        await messageBus.PublishAsync(integrationEvent, exchange: "task.events", routingKey: "task.created", cancellationToken);
+        await notificationDispatcher.DispatchAsync(integrationEvent, routingKey: "task.created", cancellationToken);
     }
 }

--- a/src/Application/Features/Tasks/EventHandlers/TaskStatusUpdatedEventHandler.cs
+++ b/src/Application/Features/Tasks/EventHandlers/TaskStatusUpdatedEventHandler.cs
@@ -8,7 +8,7 @@ namespace Application.Features.Tasks.EventHandlers;
 
 public class TaskStatusUpdatedEventHandler(
     IApplicationDbContext applicationDb,
-    IMessageBus messageBus
+    INotificationDispatcher notificationDispatcher
     ) : INotificationHandler<TaskStatusUpdatedEvent>
 {
     public async Task Handle(TaskStatusUpdatedEvent notification, CancellationToken cancellationToken)
@@ -26,7 +26,7 @@ public class TaskStatusUpdatedEventHandler(
                 Message = message,
                 UserId = task.CreatorId
             };
-            await messageBus.PublishAsync(integrationEvent, exchange: "task.events", routingKey: "task.updated", cancellationToken);
+            await notificationDispatcher.DispatchAsync(integrationEvent, routingKey: "task.updated", cancellationToken);
         }
     }
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -36,6 +36,7 @@ public static class DependencyInjection
     {
         var connectionString = configuration.GetConnectionString("DefaultConnection")
                                ?? throw new InvalidOperationException("Connection string not found.");
+        var notificationDispatchMode = GetNotificationDispatchMode(configuration);
         
         QuestPDF.Settings.License = LicenseType.Community;
         services.AddScoped<ISaveChangesInterceptor, AuditableEntityInterceptor>();
@@ -129,18 +130,27 @@ public static class DependencyInjection
             return cloudinary;
         });
         services.AddSingleton<IBackgroundJobSignal, BackgroundJobSignal>();
-        services.AddSingleton<IMessageBus>((sp) =>
+        if (notificationDispatchMode.Equals(NotificationDispatchModes.RabbitMq, StringComparison.OrdinalIgnoreCase))
         {
-            var config = sp.GetRequiredService<IConfiguration>();
+            services.AddSingleton<IMessageBus>((sp) =>
+            {
+                var config = sp.GetRequiredService<IConfiguration>();
 
-            var hostName = config.GetValue<string>("RabbitMq:HostName") ?? "localhost";
-            var userName = config.GetValue<string>("RabbitMq:UserName") ?? "admin";
-            var password = config.GetValue<string>("RabbitMq:Password") ?? "admin";
-            var virtualHost = config.GetValue<string>("RabbitMq:VirtualHost") ?? "/";
-            var port = config.GetValue<int?>("RabbitMq:Port") ?? 5672;
-            var useSsl = config.GetValue<bool>("RabbitMq:UseSsl");
-            return new RabbitMqMessageBus(hostName, userName, password, virtualHost, port, useSsl);
-        });
+                var hostName = config.GetValue<string>("RabbitMq:HostName") ?? "localhost";
+                var userName = config.GetValue<string>("RabbitMq:UserName") ?? "admin";
+                var password = config.GetValue<string>("RabbitMq:Password") ?? "admin";
+                var virtualHost = config.GetValue<string>("RabbitMq:VirtualHost") ?? "/";
+                var port = config.GetValue<int?>("RabbitMq:Port") ?? 5672;
+                var useSsl = config.GetValue<bool>("RabbitMq:UseSsl");
+                return new RabbitMqMessageBus(hostName, userName, password, virtualHost, port, useSsl);
+            });
+            services.AddScoped<INotificationDispatcher, RabbitMqNotificationDispatcher>();
+        }
+        else
+        {
+            services.AddScoped<INotificationDispatcher, InProcessNotificationDispatcher>();
+        }
+
         services.AddMemoryCache();
         services.AddSingleton<IConnectionMultiplexer>(sp =>
         {
@@ -157,5 +167,26 @@ public static class DependencyInjection
             return ConnectionMultiplexer.Connect(redisOptions);
         });
         services.AddScoped<IRedisCacheService, RedisCacheService>();
+    }
+
+    private static string GetNotificationDispatchMode(IConfiguration configuration)
+    {
+        var configuredMode = configuration[$"{NotificationDispatchOptions.SectionName}:DispatchMode"];
+        if (!string.IsNullOrWhiteSpace(configuredMode))
+        {
+            if (configuredMode.Equals(NotificationDispatchModes.InProcess, StringComparison.OrdinalIgnoreCase)
+                || configuredMode.Equals(NotificationDispatchModes.RabbitMq, StringComparison.OrdinalIgnoreCase))
+            {
+                return configuredMode;
+            }
+
+            throw new InvalidOperationException(
+                $"Unsupported notification dispatch mode '{configuredMode}'. Supported values are '{NotificationDispatchModes.InProcess}' and '{NotificationDispatchModes.RabbitMq}'.");
+        }
+
+        var environment = configuration["ASPNETCORE_ENVIRONMENT"];
+        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase)
+            ? NotificationDispatchModes.RabbitMq
+            : NotificationDispatchModes.InProcess;
     }
 }

--- a/src/Infrastructure/Notifications/InProcessNotificationDispatcher.cs
+++ b/src/Infrastructure/Notifications/InProcessNotificationDispatcher.cs
@@ -1,0 +1,33 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using Domain.ValueObjects;
+using Task = System.Threading.Tasks.Task;
+
+namespace Infrastructure.Notifications;
+
+public sealed class InProcessNotificationDispatcher(
+    IApplicationDbContext applicationDbContext,
+    INotificationPublisherService notificationPublisherService) : INotificationDispatcher
+{
+    public async Task DispatchAsync(
+        NotificationIntegrationEvent notification,
+        string routingKey,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = new Notification(notification.UserId, notification.Type, notification.Message);
+
+        if (!string.IsNullOrWhiteSpace(notification.ActionUrl)
+            && !string.IsNullOrWhiteSpace(notification.ActionLabel))
+        {
+            entity.Action = new NotificationAction
+            {
+                ActionUrl = notification.ActionUrl,
+                ActionLabel = notification.ActionLabel
+            };
+        }
+
+        applicationDbContext.Notifications.Add(entity);
+        await notificationPublisherService.PublishToUserAsync(notification.UserId, entity);
+    }
+}

--- a/src/Infrastructure/Notifications/NotificationService.cs
+++ b/src/Infrastructure/Notifications/NotificationService.cs
@@ -11,27 +11,17 @@ public class NotificationService(IApplicationDbContext applicationDbContext,
 {
     public async Task<Guid> CreateNotificationAsync(string userId, string message, NotificationType type, string? actionUrl, string? actionLabel)
     {
-        
-        // var notification = string.IsNullOrEmpty(actionUrl) && string.IsNullOrEmpty(actionLabel) 
-        //     ? new Notification(userId, type, message)
-        //     : new Notification(userId, type, message)
-        //     {
-        //         Action = new NotificationAction()
-        //         {
-        //             ActionUrl = actionUrl!,
-        //             ActionLabel = actionLabel!
-        //         }
-        //     };
+        var notification = new Notification(userId, type, message);
 
-        var notification = new Notification(userId, type, message)
+        if (!string.IsNullOrWhiteSpace(actionUrl)
+            && !string.IsNullOrWhiteSpace(actionLabel))
         {
-             // ActionUrl = actionUrl!, ActionLabel = actionLabel! 
-             Action = new NotificationAction()
-             {
-                 ActionUrl = actionUrl!,
-                 ActionLabel = actionLabel!
-             }
-        };
+            notification.Action = new NotificationAction
+            {
+                ActionUrl = actionUrl,
+                ActionLabel = actionLabel
+            };
+        }
         
         applicationDbContext.Notifications.Add(notification);
         await applicationDbContext.SaveChangesAsync(CancellationToken.None);

--- a/src/Infrastructure/Notifications/RabbitMqNotificationDispatcher.cs
+++ b/src/Infrastructure/Notifications/RabbitMqNotificationDispatcher.cs
@@ -1,0 +1,19 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+
+namespace Infrastructure.Notifications;
+
+public sealed class RabbitMqNotificationDispatcher(IMessageBus messageBus) : INotificationDispatcher
+{
+    public Task DispatchAsync(
+        NotificationIntegrationEvent notification,
+        string routingKey,
+        CancellationToken cancellationToken = default)
+    {
+        return messageBus.PublishAsync(
+            notification,
+            exchange: "task.events",
+            routingKey: routingKey,
+            cancellationToken);
+    }
+}

--- a/src/NotificationWorker/Worker.cs
+++ b/src/NotificationWorker/Worker.cs
@@ -64,8 +64,8 @@ public class Worker(
             UserId = message.UserId!,
             Message = message.Message,
             Type = message.Type,
-            ActionUrl = (string?)null,
-            ActionLabel = (string?)null
+            ActionUrl = message.ActionUrl,
+            ActionLabel = message.ActionLabel
         });
         
         response.EnsureSuccessStatusCode();

--- a/src/Web/DependencyInjection.cs
+++ b/src/Web/DependencyInjection.cs
@@ -56,10 +56,36 @@ public static class DependencyInjection
             });
             
         });
-        services.AddHealthChecks()
+        var healthChecks = services.AddHealthChecks()
             .AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live", "ready"])
             .AddNpgSql(connectionString, name: "postgresql", tags: ["ready"])
-            .AddCheck<RedisHealthCheck>("redis", tags: ["ready"])
-            .AddCheck<RabbitMqHealthCheck>("rabbitmq", tags: ["ready"]);
+            .AddCheck<RedisHealthCheck>("redis", tags: ["ready"]);
+
+        if (IsRabbitMqNotificationDispatchEnabled(configuration))
+        {
+            healthChecks.AddCheck<RabbitMqHealthCheck>("rabbitmq", tags: ["ready"]);
+        }
+    }
+
+    private static bool IsRabbitMqNotificationDispatchEnabled(IConfiguration configuration)
+    {
+        var configuredMode = configuration[$"{NotificationDispatchOptions.SectionName}:DispatchMode"];
+        if (!string.IsNullOrWhiteSpace(configuredMode))
+        {
+            if (configuredMode.Equals(NotificationDispatchModes.RabbitMq, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (configuredMode.Equals(NotificationDispatchModes.InProcess, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            throw new InvalidOperationException(
+                $"Unsupported notification dispatch mode '{configuredMode}'. Supported values are '{NotificationDispatchModes.InProcess}' and '{NotificationDispatchModes.RabbitMq}'.");
+        }
+
+        return string.Equals(configuration["ASPNETCORE_ENVIRONMENT"], "Development", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/Application.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/Application.FunctionalTests/CustomWebApplicationFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Testcontainers.PostgreSql;
+using Application.Common.Interfaces;
 using IMessageBus = Application.Common.Interfaces.IMessageBus;
 
 namespace Application.FunctionalTests;
@@ -45,6 +46,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             });
             services.RemoveAll<IMessageBus>();
             services.TryAddSingleton<IMessageBus, NoOpMessageBus>();
+            services.RemoveAll<INotificationDispatcher>();
+            services.TryAddSingleton<INotificationDispatcher, NoOpNotificationDispatcher>();
         });
     }
     public Task InitializeAsync()

--- a/tests/Application.FunctionalTests/NoOpNotificationDispatcher.cs
+++ b/tests/Application.FunctionalTests/NoOpNotificationDispatcher.cs
@@ -1,0 +1,15 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+
+namespace Application.FunctionalTests;
+
+public class NoOpNotificationDispatcher : INotificationDispatcher
+{
+    public Task DispatchAsync(
+        NotificationIntegrationEvent notification,
+        string routingKey,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Refactors notification delivery to support configurable dispatch modes.

Production can now create and push notifications directly inside the API process using InProcess mode, removing the need for the notification worker and RabbitMQ in production. Development can still use the existing
RabbitMQ + worker flow with RabbitMq mode.

Changes

- Added INotificationDispatcher abstraction.
- Added InProcessNotificationDispatcher for direct API notification creation and SignalR publishing.
- Added RabbitMqNotificationDispatcher to preserve the existing RabbitMQ worker flow.
- Added Notifications__DispatchMode configuration:
    - InProcess
    - RabbitMq
- Defaults:
    - Development -> RabbitMq
    - non-development -> InProcess
- Updated task notification event handlers to use INotificationDispatcher.
- RabbitMQ health check now only runs when RabbitMq dispatch mode is enabled.
- Updated Docker Compose:
    - development uses RabbitMq
    - production uses InProcess
- Updated notification worker to forward optional action metadata.
- Cleaned up notification action creation to avoid blank owned action objects.
- Updated README deployment documentation for the new notification modes.

Production Impact

Production no longer requires:

- notification worker dyno/container
- RabbitMQ/CloudAMQP for task notifications
- RabbitMQ health check

Production should use:

Notifications__DispatchMode=InProcess

Verification

- dotnet build Task_Management_BE.sln --no-restore passed.
- Docker web target build passed.
- Docker worker target build passed.
- HerokuConfigurationExtensionsTests passed.
- Full functional tests: 17 passed, 1 existing/unrelated failure:
    - SearchTasksTest.ShouldReturnBadRequestWhenQueryMissing
    - expected 400, received 404